### PR TITLE
chore: release

### DIFF
--- a/crates/docker_utils/CHANGELOG.md
+++ b/crates/docker_utils/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.2.0...docker_utils-v0.2.1) - 2025-01-19
+
+### Other
+
+- Updated README.md across all crates
+- Merge remote-tracking branch 'origin/main'
+- Added project wide copyright
+
 ## [0.2.0](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.1.0...docker_utils-v0.2.0) - 2025-01-19
 
 ### Other

--- a/crates/docker_utils/Cargo.toml
+++ b/crates/docker_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docker_utils"
-version = "0.2.0"
+version = "0.2.1"
 description = "Utilities for integration testsing with Docker"
 readme = "README.md"
 edition.workspace = true

--- a/crates/service_utils/CHANGELOG.md
+++ b/crates/service_utils/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/marvin-hansen/buildutils/compare/service_utils-v0.1.1...service_utils-v0.1.2) - 2025-01-19
+
+### Other
+
+- Updated README.md across all crates
+- Merge remote-tracking branch 'origin/main'
+- Added project wide copyright
+
 ## [0.1.1](https://github.com/marvin-hansen/buildutils/compare/service_utils-v0.1.0...service_utils-v0.1.1) - 2025-01-19
 
 ### Other

--- a/crates/service_utils/Cargo.toml
+++ b/crates/service_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_utils"
-version = "0.1.1"
+version = "0.1.2"
 description = "Utilities for service integration testsing"
 readme = "README.md"
 edition.workspace = true

--- a/crates/wait_utils/CHANGELOG.md
+++ b/crates/wait_utils/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/marvin-hansen/buildutils/compare/wait_utils-v0.1.1...wait_utils-v0.1.2) - 2025-01-19
+
+### Other
+
+- Updated README.md across all crates
+- Added project wide copyright
+
 ## [0.1.1](https://github.com/marvin-hansen/buildutils/compare/wait_utils-v0.1.0...wait_utils-v0.1.1) - 2025-01-19
 
 ### Other

--- a/crates/wait_utils/Cargo.toml
+++ b/crates/wait_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wait_utils"
-version = "0.1.1"
+version = "0.1.2"
 description = "Utilities for implementing wait loops using varies wait strategies"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `docker_utils`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `wait_utils`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `service_utils`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `docker_utils`
<blockquote>

## [0.2.1](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.2.0...docker_utils-v0.2.1) - 2025-01-19

### Other

- Updated README.md across all crates
- Merge remote-tracking branch 'origin/main'
- Added project wide copyright
</blockquote>

## `wait_utils`
<blockquote>

## [0.1.2](https://github.com/marvin-hansen/buildutils/compare/wait_utils-v0.1.1...wait_utils-v0.1.2) - 2025-01-19

### Other

- Updated README.md across all crates
- Added project wide copyright
</blockquote>

## `service_utils`
<blockquote>

## [0.1.2](https://github.com/marvin-hansen/buildutils/compare/service_utils-v0.1.1...service_utils-v0.1.2) - 2025-01-19

### Other

- Updated README.md across all crates
- Merge remote-tracking branch 'origin/main'
- Added project wide copyright
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).