### PR TITLE
chore: release

### DIFF
--- a/crates/docker_utils/CHANGELOG.md
+++ b/crates/docker_utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.2.2...docker_utils-v0.2.3) - 2025-01-20
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.2.2](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.2.1...docker_utils-v0.2.2) - 2025-01-20
 
 ### Other

--- a/crates/docker_utils/Cargo.toml
+++ b/crates/docker_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docker_utils"
-version = "0.2.2"
+version = "0.2.3"
 description = "Utilities for integration testsing with Docker"
 readme = "README.md"
 edition.workspace = true

--- a/crates/service_utils/CHANGELOG.md
+++ b/crates/service_utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/marvin-hansen/buildutils/compare/service_utils-v0.1.3...service_utils-v0.1.4) - 2025-01-20
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.3](https://github.com/marvin-hansen/buildutils/compare/service_utils-v0.1.2...service_utils-v0.1.3) - 2025-01-20
 
 ### Other

--- a/crates/service_utils/Cargo.toml
+++ b/crates/service_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_utils"
-version = "0.1.3"
+version = "0.1.4"
 description = "Utilities for service integration testsing"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `docker_utils`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `service_utils`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `docker_utils`
<blockquote>

## [0.2.3](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.2.2...docker_utils-v0.2.3) - 2025-01-20

### Other

- update Cargo.toml dependencies
</blockquote>

## `service_utils`
<blockquote>

## [0.1.4](https://github.com/marvin-hansen/buildutils/compare/service_utils-v0.1.3...service_utils-v0.1.4) - 2025-01-20

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).