### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ deprecated_safe_2024 = "warn"
 # Internal Aliases
 # ==============
 docker_utils = { path = "crates/docker_utils", version = "0.2" }
-service_utils = { path = "crates/service_utils", version = "0.1" }
+service_utils = { path = "crates/service_utils", version = "0.2" }
 wait_utils = { path = "crates/wait_utils", version = "0.1" }
 service_example = { path = "examples/service_example" }
 # ==============

--- a/crates/docker_utils/CHANGELOG.md
+++ b/crates/docker_utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.2.3...docker_utils-v0.2.4) - 2025-10-07
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.2.3](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.2.2...docker_utils-v0.2.3) - 2025-01-20
 
 ### Other

--- a/crates/docker_utils/Cargo.toml
+++ b/crates/docker_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docker_utils"
-version = "0.2.3"
+version = "0.2.4"
 description = "Utilities for integration testsing with Docker"
 readme = "README.md"
 edition.workspace = true

--- a/crates/service_utils/CHANGELOG.md
+++ b/crates/service_utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/marvin-hansen/buildutils/compare/service_utils-v0.2.0...service_utils-v0.2.1) - 2025-10-07
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.2.0](https://github.com/marvin-hansen/buildutils/compare/service_utils-v0.1.6...service_utils-v0.2.0) - 2025-01-22
 
 ### Other

--- a/crates/service_utils/Cargo.toml
+++ b/crates/service_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_utils"
-version = "0.2.0"
+version = "0.2.1"
 description = "Utilities for service integration testsing"
 readme = "README.md"
 edition.workspace = true

--- a/crates/wait_utils/CHANGELOG.md
+++ b/crates/wait_utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/marvin-hansen/buildutils/compare/wait_utils-v0.1.3...wait_utils-v0.1.4) - 2025-10-07
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.3](https://github.com/marvin-hansen/buildutils/compare/wait_utils-v0.1.2...wait_utils-v0.1.3) - 2025-01-20
 
 ### Other

--- a/crates/wait_utils/Cargo.toml
+++ b/crates/wait_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wait_utils"
-version = "0.1.3"
+version = "0.1.4"
 description = "Utilities for implementing wait loops using varies wait strategies"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `wait_utils`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `docker_utils`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `service_utils`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `wait_utils`

<blockquote>

## [0.1.4](https://github.com/marvin-hansen/buildutils/compare/wait_utils-v0.1.3...wait_utils-v0.1.4) - 2025-10-07

### Other

- update Cargo.toml dependencies
</blockquote>

## `docker_utils`

<blockquote>

## [0.2.4](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.2.3...docker_utils-v0.2.4) - 2025-10-07

### Other

- update Cargo.toml dependencies
</blockquote>

## `service_utils`

<blockquote>

## [0.2.1](https://github.com/marvin-hansen/buildutils/compare/service_utils-v0.2.0...service_utils-v0.2.1) - 2025-10-07

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).