### PR TITLE
chore: release

### DIFF
--- a/crates/docker_utils/CHANGELOG.md
+++ b/crates/docker_utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.3.0...docker_utils-v0.3.1) - 2026-07-28
+
+### Fixed
+
+- *(wait_utils)* respect the HTTP status and stderr when waiting
+
 ## [0.3.0](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.2.4...docker_utils-v0.3.0) - 2026-07-28
 
 ### Added

--- a/crates/docker_utils/Cargo.toml
+++ b/crates/docker_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docker_utils"
-version = "0.3.0"
+version = "0.3.1"
 description = "Utilities for integration testsing with Docker"
 readme = "README.md"
 edition.workspace = true

--- a/crates/wait_utils/CHANGELOG.md
+++ b/crates/wait_utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/marvin-hansen/buildutils/compare/wait_utils-v0.1.5...wait_utils-v0.1.6) - 2026-07-28
+
+### Fixed
+
+- *(wait_utils)* respect the HTTP status and stderr when waiting
+
 ## [0.1.5](https://github.com/marvin-hansen/buildutils/compare/wait_utils-v0.1.4...wait_utils-v0.1.5) - 2026-07-28
 
 ### Other

--- a/crates/wait_utils/Cargo.toml
+++ b/crates/wait_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wait_utils"
-version = "0.1.5"
+version = "0.1.6"
 description = "Utilities for implementing wait loops using varies wait strategies"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `wait_utils`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `docker_utils`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `wait_utils`

<blockquote>

## [0.1.6](https://github.com/marvin-hansen/buildutils/compare/wait_utils-v0.1.5...wait_utils-v0.1.6) - 2026-07-28

### Fixed

- *(wait_utils)* respect the HTTP status and stderr when waiting
</blockquote>

## `docker_utils`

<blockquote>

## [0.3.1](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.3.0...docker_utils-v0.3.1) - 2026-07-28

### Fixed

- *(wait_utils)* respect the HTTP status and stderr when waiting
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).