### PR TITLE
chore: release

### DIFF
--- a/crates/docker_utils/CHANGELOG.md
+++ b/crates/docker_utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.3.1...docker_utils-v0.3.2) - 2026-07-29
+
+### Added
+
+- add container diagnostics and a caller-supplied readiness probe
+
 ## [0.3.1](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.3.0...docker_utils-v0.3.1) - 2026-07-28
 
 ### Fixed

--- a/crates/docker_utils/Cargo.toml
+++ b/crates/docker_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docker_utils"
-version = "0.3.1"
+version = "0.3.2"
 description = "Utilities for integration testsing with Docker"
 readme = "README.md"
 edition.workspace = true

--- a/crates/service_utils/CHANGELOG.md
+++ b/crates/service_utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/marvin-hansen/buildutils/compare/service_utils-v0.2.2...service_utils-v0.2.3) - 2026-07-29
+
+### Added
+
+- add container diagnostics and a caller-supplied readiness probe
+
 ## [0.2.2](https://github.com/marvin-hansen/buildutils/compare/service_utils-v0.2.1...service_utils-v0.2.2) - 2026-07-28
 
 ### Other

--- a/crates/service_utils/Cargo.toml
+++ b/crates/service_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_utils"
-version = "0.2.2"
+version = "0.2.3"
 description = "Utilities for service integration testsing"
 readme = "README.md"
 edition.workspace = true

--- a/crates/wait_utils/CHANGELOG.md
+++ b/crates/wait_utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/marvin-hansen/buildutils/compare/wait_utils-v0.1.6...wait_utils-v0.1.7) - 2026-07-29
+
+### Added
+
+- add container diagnostics and a caller-supplied readiness probe
+
 ## [0.1.6](https://github.com/marvin-hansen/buildutils/compare/wait_utils-v0.1.5...wait_utils-v0.1.6) - 2026-07-28
 
 ### Fixed

--- a/crates/wait_utils/Cargo.toml
+++ b/crates/wait_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wait_utils"
-version = "0.1.6"
+version = "0.1.7"
 description = "Utilities for implementing wait loops using varies wait strategies"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `wait_utils`: 0.1.6 -> 0.1.7 (✓ API compatible changes)
* `docker_utils`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `service_utils`: 0.2.2 -> 0.2.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `wait_utils`

<blockquote>

## [0.1.7](https://github.com/marvin-hansen/buildutils/compare/wait_utils-v0.1.6...wait_utils-v0.1.7) - 2026-07-29

### Added

- add container diagnostics and a caller-supplied readiness probe
</blockquote>

## `docker_utils`

<blockquote>

## [0.3.2](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.3.1...docker_utils-v0.3.2) - 2026-07-29

### Added

- add container diagnostics and a caller-supplied readiness probe
</blockquote>

## `service_utils`

<blockquote>

## [0.2.3](https://github.com/marvin-hansen/buildutils/compare/service_utils-v0.2.2...service_utils-v0.2.3) - 2026-07-29

### Added

- add container diagnostics and a caller-supplied readiness probe
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).