### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ deprecated_safe_2024 = "warn"
 # Internal Aliases
 # ==============
 docker_utils = { path = "crates/docker_utils", version = "0.3" }
-service_utils = { path = "crates/service_utils", version = "0.2" }
-wait_utils = { path = "crates/wait_utils", version = "0.1" }
+service_utils = { path = "crates/service_utils", version = "0.3" }
+wait_utils = { path = "crates/wait_utils", version = "0.2" }
 service_example = { path = "examples/service_example" }
 # ==============
 # External crates

--- a/crates/docker_utils/CHANGELOG.md
+++ b/crates/docker_utils/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.3.2...docker_utils-v0.3.3) - 2026-07-29
+
+### Added
+
+- honour a caller-supplied readiness probe in both drivers
+
+### Other
+
+- Merge remote-tracking branch 'origin/main'
+
 ## [0.3.2](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.3.1...docker_utils-v0.3.2) - 2026-07-29
 
 ### Added

--- a/crates/docker_utils/Cargo.toml
+++ b/crates/docker_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docker_utils"
-version = "0.3.2"
+version = "0.3.3"
 description = "Utilities for integration testsing with Docker"
 readme = "README.md"
 edition.workspace = true

--- a/crates/service_utils/CHANGELOG.md
+++ b/crates/service_utils/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/marvin-hansen/buildutils/compare/service_utils-v0.2.3...service_utils-v0.3.0) - 2026-07-29
+
+### Added
+
+- honour a caller-supplied readiness probe in both drivers
+
+### Other
+
+- Merge remote-tracking branch 'origin/main'
+
 ## [0.2.3](https://github.com/marvin-hansen/buildutils/compare/service_utils-v0.2.2...service_utils-v0.2.3) - 2026-07-29
 
 ### Added

--- a/crates/service_utils/Cargo.toml
+++ b/crates/service_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_utils"
-version = "0.2.3"
+version = "0.3.0"
 description = "Utilities for service integration testsing"
 readme = "README.md"
 edition.workspace = true

--- a/crates/wait_utils/CHANGELOG.md
+++ b/crates/wait_utils/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/marvin-hansen/buildutils/compare/wait_utils-v0.1.7...wait_utils-v0.2.0) - 2026-07-29
+
+### Added
+
+- honour a caller-supplied readiness probe in both drivers
+
+### Other
+
+- Merge remote-tracking branch 'origin/main'
+
 ## [0.1.7](https://github.com/marvin-hansen/buildutils/compare/wait_utils-v0.1.6...wait_utils-v0.1.7) - 2026-07-29
 
 ### Added

--- a/crates/wait_utils/Cargo.toml
+++ b/crates/wait_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wait_utils"
-version = "0.1.7"
+version = "0.2.0"
 description = "Utilities for implementing wait loops using varies wait strategies"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `wait_utils`: 0.1.7 -> 0.2.0 (⚠ API breaking changes)
* `docker_utils`: 0.3.2 -> 0.3.3 (✓ API compatible changes)
* `service_utils`: 0.2.3 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `wait_utils` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant WaitStrategy:WaitUntilReady in /tmp/.tmpL4k3Ze/buildutils/crates/wait_utils/src/types/enum_wait_strategy.rs:99

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function wait_utils::wait_until_ready_async, previously in file /tmp/.tmphT85MZ/wait_utils/src/wait_strategies/wait_until_ready.rs:149
```

### ⚠ `service_utils` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  service_utils::ServiceStartConfig::new takes 4 parameters in /tmp/.tmphT85MZ/service_utils/src/service_config.rs:77, but now takes 6 parameters in /tmp/.tmpL4k3Ze/buildutils/crates/service_utils/src/service_config.rs:98
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `wait_utils`

<blockquote>

## [0.2.0](https://github.com/marvin-hansen/buildutils/compare/wait_utils-v0.1.7...wait_utils-v0.2.0) - 2026-07-29

### Added

- honour a caller-supplied readiness probe in both drivers

### Other

- Merge remote-tracking branch 'origin/main'
</blockquote>

## `docker_utils`

<blockquote>

## [0.3.3](https://github.com/marvin-hansen/buildutils/compare/docker_utils-v0.3.2...docker_utils-v0.3.3) - 2026-07-29

### Added

- honour a caller-supplied readiness probe in both drivers

### Other

- Merge remote-tracking branch 'origin/main'
</blockquote>

## `service_utils`

<blockquote>

## [0.3.0](https://github.com/marvin-hansen/buildutils/compare/service_utils-v0.2.3...service_utils-v0.3.0) - 2026-07-29

### Added

- honour a caller-supplied readiness probe in both drivers

### Other

- Merge remote-tracking branch 'origin/main'
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).